### PR TITLE
Remove duplicated  fk_answer_question CONSTRAINT

### DIFF
--- a/polls-database-schema/polls-schema.sql
+++ b/polls-database-schema/polls-schema.sql
@@ -93,16 +93,11 @@ CREATE TABLE poll_answer (
     REFERENCES poll (id)
     ON DELETE NO ACTION
     ON UPDATE NO ACTION,
-    CONSTRAINT fk_answer_question
-  FOREIGN KEY (questionId)
-  REFERENCES poll_question (id)
-  ON DELETE NO ACTION
-  ON UPDATE NO ACTION,
   CONSTRAINT fk_answer_question
-  FOREIGN KEY (questionId)
-  REFERENCES poll_question (id)
-  ON DELETE NO ACTION
-  ON UPDATE NO ACTION);
+    FOREIGN KEY (questionId)
+    REFERENCES poll_question (id)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION);
 
 CREATE INDEX idx_answer_poll ON poll_answer (pollId ASC);
 CREATE INDEX idx_answer_question ON poll_answer (questionId ASC);


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* The script to create a sample polls database had a duplicated foreign key constraint on the poll_answer table

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
* Create the polls database using any postrges client
* Run the rest of the script excluding CREATE DATABASE poll

## What to Check
Verify that the following are valid
* Run `CREATE DATABASE  poll`  using any postgres client
* Switch to the newly created poll database before executing the rest of the script to create the tables

## Other Information
<!-- Add any other helpful information that may be needed here. -->